### PR TITLE
Cleaner way to allow multiple trailers and boats

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,12 +1,16 @@
 -----------------------------------
 --- Boat Trailer, Made by FAXES ---
 -----------------------------------
+-- Modified by Xodus989 for Miami Roleplay to allow
+-- multiple boats and trailers to be used easily.
 
 --- Config ---
 
 attachKey = 51 -- Index number for attach key - http://docs.fivem.net/game-references/controls/
 attachKeyName = "~INPUT_CONTEXT~" -- Key name (center column) of above key.
 
+local BOATS = {'DINGHY', 'code3boat', 'HILLBOATY'} -- Define all the boats that can attach to the trailer (Xodus989)
+local TRAILERS = {'BOATTRAILER'} --Define all the possible trailers (Xodus989)
 --- Code ---
 
 function GetVehicleInDirection(cFrom, cTo)
@@ -21,33 +25,37 @@ Citizen.CreateThread(function()
         local ped = GetPlayerPed(-1) -- Made the whole thing forgot to add this line lol, maybe thats why it broke #4:32AMLife
         local veh = GetVehiclePedIsIn(ped)
         if veh ~= nil then
-            if GetDisplayNameFromVehicleModel(GetEntityModel(veh)) == "DINGHY" then -- After a few hours here at 4am GetDisplayNameFromVehicleModel() got it working well :P
-                local belowFaxMachine = GetOffsetFromEntityInWorldCoords(veh, 1.0, 0.0, -1.0)
-				local boatCoordsInWorldLol = GetEntityCoords(veh)
-                local trailerLoc = GetVehicleInDirection(boatCoordsInWorldLol, belowFaxMachine)
-                
-				if GetDisplayNameFromVehicleModel(GetEntityModel(trailerLoc)) == "BOATTRAILER" then -- Is there a trailer????
-                    if IsEntityAttached(veh) then -- Is boat already attached?
-                        if IsControlJustReleased(1, attachKey) then -- detach
-							DetachEntity(veh, false, true)
-						end
-                        -- Start Prompt
-                        Citizen.InvokeNative(0x8509B634FBE7DA11, "STRING") -- BeginTextCommandDisplayHelp()
-						Citizen.InvokeNative(0x5F68520888E69014, "Press " .. attachKeyName .. " to detach boat.") -- AddTextComponentScaleform()
-						Citizen.InvokeNative(0x238FFE5C7B0498A6, 0, false, true, -1) -- EndTextCommandDisplayHelp()
-                    else
-                        if IsControlJustReleased(1, attachKey) then -- Attach
-							AttachEntityToEntity(veh, trailerLoc, 20, 0.0, -1.0, 0.25, 0.0, 0.0, 0.0, false, false, true, false, 20, true)
-							TaskLeaveVehicle(ped, veh, 64)
+            for v, boat in ipairs(BOATS) do -- Iterate through potential boats to attach and check if we're in one (Xodus989)
+                if GetDisplayNameFromVehicleModel(GetEntityModel(veh)) == tostring(boat) then -- After a few hours here at 4am GetDisplayNameFromVehicleModel() got it working well :P
+                    local belowFaxMachine = GetOffsetFromEntityInWorldCoords(veh, 1.0, 0.0, -1.0)
+                    local boatCoordsInWorldLol = GetEntityCoords(veh)
+                    local trailerLoc = GetVehicleInDirection(boatCoordsInWorldLol, belowFaxMachine)
+  
+                    for t, trailer in ipairs(TRAILERS) do -- Iterate through potential trailers and see if they exist (Xodus989)
+                        if GetDisplayNameFromVehicleModel(GetEntityModel(trailerLoc)) == tostring(trailer) then -- Is there a trailer????
+                            if IsEntityAttached(veh) then -- Is boat already attached?
+                                if IsControlJustReleased(1, attachKey) then -- detach
+                                    DetachEntity(veh, false, true)
+                                end
+                                -- Start Prompt
+                                Citizen.InvokeNative(0x8509B634FBE7DA11, "STRING") -- BeginTextCommandDisplayHelp()
+                                Citizen.InvokeNative(0x5F68520888E69014, "Press " .. attachKeyName .. " to detach boat.") -- AddTextComponentScaleform()
+                                Citizen.InvokeNative(0x238FFE5C7B0498A6, 0, false, true, -1) -- EndTextCommandDisplayHelp()
+                            else
+                                if IsControlJustReleased(1, attachKey) then -- Attach
+                                    AttachEntityToEntity(veh, trailerLoc, 20, 0.0, -1.0, 0.25, 0.0, 0.0, 0.0, false, false, true, false, 20, true)
+                                    TaskLeaveVehicle(ped, veh, 64)
+                                end
+                                -- Start Prompt
+                                Citizen.InvokeNative(0x8509B634FBE7DA11, "STRING") -- BeginTextCommandDisplayHelp()
+                                Citizen.InvokeNative(0x5F68520888E69014, "Press " .. attachKeyName .. " to attach boat.") -- AddTextComponentScaleform()
+                                Citizen.InvokeNative(0x238FFE5C7B0498A6, 0, false, true, -1) -- EndTextCommandDisplayHelp()
+                                -- Made by Faxes with some help of the bois
+                            end
                         end
-                        -- Start Prompt
-                        Citizen.InvokeNative(0x8509B634FBE7DA11, "STRING") -- BeginTextCommandDisplayHelp()
-						Citizen.InvokeNative(0x5F68520888E69014, "Press " .. attachKeyName .. " to attach boat.") -- AddTextComponentScaleform()
-						Citizen.InvokeNative(0x238FFE5C7B0498A6, 0, false, true, -1) -- EndTextCommandDisplayHelp()
-                        -- Made by Faxes with some help of the bois
-					end
                 end
-            end
+                end
+            end     
         end
     end
     -- Just a comment here. Why the fuck not? Its 6 am now


### PR DESCRIPTION
The other pull request is extremely complicated and is pretty limited. This allows users to easier customize which boats are allowed onto the trailer.

Boats and trailers are defined in an array and then iterated through at the two appropriate points to see if script should fire attachments.

![boats](https://user-images.githubusercontent.com/6455995/140268696-09045d69-1f7b-4445-93da-bb577ca98b72.png)